### PR TITLE
Add badge support for projects

### DIFF
--- a/components/CompactProjectCard.tsx
+++ b/components/CompactProjectCard.tsx
@@ -40,6 +40,19 @@ const CompactProjectCard: React.FC<CompactProjectCardProps> = ({
         {formatDate(project.startDate)} – {formatDate(project.endDate)}
       </div>
 
+      {project.badges && project.badges.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {project.badges.map((badge) => (
+            <span
+              key={badge}
+              className="rounded-full border border-amber-300/25 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-100"
+            >
+              {badge}
+            </span>
+          ))}
+        </div>
+      )}
+
       {/* Fortschritt */}
       {typeof project.fortschritt === 'number' && (
         <div className="w-full h-2 bg-gray-700/60 rounded overflow-hidden">

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -33,6 +33,32 @@ const normalizePhase = (val?: string): ProjectPhase => {
   return allowed.includes(lowered as ProjectPhase) ? (lowered as ProjectPhase) : 'initialisierung';
 };
 
+const normalizeBadgeList = (value: unknown): string[] => {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return Array.from(
+      new Set(
+        value
+          .map((entry) => String(entry || '').trim())
+          .filter(Boolean)
+      )
+    );
+  }
+
+  if (typeof value === 'string') {
+    return Array.from(
+      new Set(
+        value
+          .split(/[\n,;]+/)
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+      )
+    );
+  }
+
+  return [];
+};
+
 const ProjectForm: React.FC<ProjectFormProps> = ({
   initialProject,
   categories,
@@ -57,6 +83,8 @@ const ProjectForm: React.FC<ProjectFormProps> = ({
   const [selectedCategory, setSelectedCategory] = useState<string>(() =>
     normalizeCategoryId(initialProject?.category || '', categories)
   );
+  const [badges, setBadges] = useState<string[]>(() => normalizeBadgeList(initialProject?.badges));
+  const [newBadge, setNewBadge] = useState('');
 
   // Zusätzliche Felder aus dem SharePoint-Schema
   const [projektleitung, setProjektleitung] = useState(initialProject?.projektleitung || '');
@@ -191,6 +219,7 @@ const ProjectForm: React.FC<ProjectFormProps> = ({
     setStartDate(initialProject.startDate ? new Date(initialProject.startDate) : null);
     setEndDate(initialProject.endDate ? new Date(initialProject.endDate) : null);
     setSelectedCategory(normalizeCategoryId(initialProject.category || '', categories));
+    setBadges(normalizeBadgeList(initialProject.badges));
     setProjektleitung(initialProject.projektleitung || '');
     setBisher(initialProject.bisher || '');
     setZukunft(initialProject.zukunft || '');
@@ -268,6 +297,21 @@ const ProjectForm: React.FC<ProjectFormProps> = ({
   // Function to remove a team member from the project
   const handleRemoveTeamMember = (memberId: string) => {
     setTeamMembers((prevMembers) => prevMembers.filter((member) => member.id !== memberId));
+  };
+
+  const addBadge = () => {
+    const normalized = newBadge.trim();
+    if (!normalized) return;
+
+    setBadges((prev) => {
+      const exists = prev.some((badge) => badge.toLowerCase() === normalized.toLowerCase());
+      return exists ? prev : [...prev, normalized];
+    });
+    setNewBadge('');
+  };
+
+  const removeBadge = (badgeToRemove: string) => {
+    setBadges((prev) => prev.filter((badge) => badge !== badgeToRemove));
   };
 
   // Kategorie auswählen
@@ -404,6 +448,7 @@ const ProjectForm: React.FC<ProjectFormProps> = ({
       startDate: startDate ? startDate.toISOString() : '',
       endDate: endDate ? endDate.toISOString() : '',
       projektleitung,
+      badges,
       bisher,
       zukunft,
       fortschritt,
@@ -427,6 +472,68 @@ const ProjectForm: React.FC<ProjectFormProps> = ({
     { id: 'security', name: 'Sicherheit', description: 'Sicherheitsaspekte' },
     { id: 'infrastructure', name: 'Infrastruktur', description: 'Infrastrukturaspekte' },
   ];
+
+  const badgesEditor = (
+    <div className="mt-2">
+      <h3 className="text-lg font-medium mb-2">Badges (optional)</h3>
+      <div className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-5">
+        <p className="mb-4 text-sm text-slate-300">
+          Badges werden nur in der Kachelansicht angezeigt und können dort zusätzlich gefiltert werden.
+        </p>
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-7">
+          <div className="md:col-span-6">
+            <input
+              type="text"
+              value={newBadge}
+              onChange={(e) => setNewBadge(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ',') {
+                  e.preventDefault();
+                  addBadge();
+                }
+              }}
+              placeholder="Badge eingeben, z.B. Pilot, Priorität, KI"
+              className="w-full rounded-2xl border border-slate-800/70 bg-slate-950 px-4 py-2 text-sm text-slate-100 placeholder-slate-500 outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-400/30"
+            />
+          </div>
+          <div className="md:col-span-1">
+            <button
+              type="button"
+              onClick={addBadge}
+              className="flex w-full items-center justify-center rounded-full bg-sky-500 px-4 py-2 text-white transition hover:bg-sky-400 disabled:opacity-60"
+              disabled={!newBadge.trim()}
+            >
+              <FaPlus />
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-2">
+          {badges.length > 0 ? (
+            badges.map((badge) => (
+              <span
+                key={badge}
+                className="inline-flex items-center gap-2 rounded-full border border-amber-400/30 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-100"
+              >
+                {badge}
+                <button
+                  type="button"
+                  onClick={() => removeBadge(badge)}
+                  className="rounded-full border border-amber-300/20 px-1 text-[10px] leading-none text-amber-100 transition hover:bg-amber-400/10"
+                  aria-label={`${badge} entfernen`}
+                >
+                  ×
+                </button>
+              </span>
+            ))
+          ) : (
+            <p className="text-sm text-slate-400">Keine Badges angelegt</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
@@ -664,6 +771,8 @@ const ProjectForm: React.FC<ProjectFormProps> = ({
                 placeholder="z.B. Go-Live Q3 2025"
               />
             </div>
+
+            {badgesEditor}
 
             {/* Bisher */}
             <div>
@@ -997,6 +1106,8 @@ const ProjectForm: React.FC<ProjectFormProps> = ({
               placeholder="z.B. Go-Live Q3 2025"
             />
           </div>
+
+          {badgesEditor}
 
           {/* Bisher */}
           <div>

--- a/components/Roadmap.tsx
+++ b/components/Roadmap.tsx
@@ -73,6 +73,7 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
   });
   const [filterText, setFilterText] = useState('');
   const [statusFilters, setStatusFilters] = useState<string[]>([]);
+  const [badgeFilters, setBadgeFilters] = useState<string[]>([]);
   const [tagFilters, setTagFilters] = useState<string[]>([]);
   const [projectTypeFilters, setProjectTypeFilters] = useState<string[]>([]);
   const [phaseFilters, setPhaseFilters] = useState<string[]>([]);
@@ -141,6 +142,7 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
     const {
       q,
       status,
+      badges,
       tags,
       ptype,
       phase,
@@ -157,6 +159,10 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
     if (status) {
       const list = Array.isArray(status) ? status : status.split(',');
       setStatusFilters(list.filter(Boolean).map((s) => s.toLowerCase()));
+    }
+    if (badges) {
+      const list = Array.isArray(badges) ? badges : badges.split(',');
+      setBadgeFilters(list.filter(Boolean));
     }
     if (tags) {
       const list = Array.isArray(tags) ? tags : tags.split(',');
@@ -206,6 +212,7 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
   useEffect(() => {
     const readQuery = (q: ParsedUrlQuery) => {
       const rawStatus = q['status'];
+      const rawBadges = q['badges'];
       const rawTags = q['tags'];
       const rawTypes = q['ptype'];
       const rawPhases = q['phase'];
@@ -225,6 +232,9 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
         .split(',')
         .filter(Boolean)
         .map((s: string) => s.toLowerCase());
+      const badges = (rawBadges ? (Array.isArray(rawBadges) ? rawBadges.join(',') : rawBadges) : '')
+        .split(',')
+        .filter(Boolean);
       const tags = (rawTags ? (Array.isArray(rawTags) ? rawTags.join(',') : rawTags) : '')
         .split(',')
         .filter(Boolean);
@@ -249,6 +259,7 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
       return {
         q: toScalar(rawQ),
         status,
+        badges,
         tags,
         ptype,
         phase,
@@ -277,6 +288,7 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
     const next = {
       q: filterText || '',
       status: [...statusFilters].map((s) => s.toLowerCase()),
+      badges: [...badgeFilters],
       tags: [...tagFilters],
       ptype: [...projectTypeFilters].map((entry) => entry.toLowerCase()),
       phase: [...phaseFilters].map((entry) => normalizePhaseValue(entry)),
@@ -303,6 +315,7 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
       const query: Record<string, string> = {};
       if (next.q) query.q = next.q;
       if (next.status.length) query.status = next.status.join(',');
+      if (next.badges.length) query.badges = next.badges.join(',');
       if (next.tags.length) query.tags = next.tags.join(',');
       if (next.ptype.length) query.ptype = next.ptype.join(',');
       if (next.phase.length) query.phase = next.phase.join(',');
@@ -324,6 +337,7 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
   }, [
     filterText,
     statusFilters,
+    badgeFilters,
     tagFilters,
     projectTypeFilters,
     phaseFilters,
@@ -440,6 +454,13 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
         .filter((value): value is string => Boolean(value))
     )
   ).sort((left, right) => left.localeCompare(right, 'de'));
+  const allBadges = Array.from(
+    new Set(
+      displayedProjects
+        .flatMap((project) => project.badges ?? [])
+        .filter((value): value is string => Boolean(value))
+    )
+  ).sort((left, right) => left.localeCompare(right, 'de'));
   const allLeads = Array.from(
     new Set(displayedProjects.map((p) => (p.projektleitung || '').trim()).filter(Boolean))
   ).sort((left, right) => left.localeCompare(right, 'de'));
@@ -459,11 +480,13 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
       const inDesc = (project.description || '').toLowerCase().includes(q);
       const inLead = (project.projektleitung || '').toLowerCase().includes(q);
       const inMilestone = (project.naechster_meilenstein || '').toLowerCase().includes(q);
+      const inBadges = (project.badges ?? []).some((value) => value.toLowerCase().includes(q));
       const inTags = (project.ProjectFields ?? []).some((value) => value.toLowerCase().includes(q));
       const inTeam = (project.teamMembers ?? []).some((member) =>
         (member.name || '').toLowerCase().includes(q)
       );
-      if (!inTitle && !inDesc && !inLead && !inMilestone && !inTags && !inTeam) return false;
+      if (!inTitle && !inDesc && !inLead && !inMilestone && !inBadges && !inTags && !inTeam)
+        return false;
     }
 
     // Status filter (if any selected)
@@ -493,6 +516,12 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
     if (leadFilters.length > 0) {
       const lead = (project.projektleitung || '').trim();
       if (!leadFilters.includes(lead)) return false;
+    }
+
+    if (badgeFilters.length > 0) {
+      const projectBadges = (project.badges ?? []).map((badge) => badge.toLowerCase());
+      const hasAnyBadge = badgeFilters.some((badge) => projectBadges.includes(badge.toLowerCase()));
+      if (!hasAnyBadge) return false;
     }
 
     // Tag filter (ProjectFields contains any of selected)
@@ -914,6 +943,15 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
                         prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]
                       )
                     }
+                    availableBadges={allBadges}
+                    selectedBadges={badgeFilters}
+                    onToggleBadge={(badge) =>
+                      setBadgeFilters((prev) =>
+                        prev.includes(badge)
+                          ? prev.filter((entry) => entry !== badge)
+                          : [...prev, badge]
+                      )
+                    }
                     availableTags={allTags}
                     selectedTags={tagFilters}
                     onToggleTag={(t) =>
@@ -962,6 +1000,7 @@ const Roadmap: React.FC<RoadmapProps> = ({ initialProjects, initialCategories })
                     onClearAll={() => {
                       setFilterText('');
                       setStatusFilters([]);
+                      setBadgeFilters([]);
                       setTagFilters([]);
                       setProjectTypeFilters([]);
                       setPhaseFilters([]);

--- a/components/RoadmapFilters.tsx
+++ b/components/RoadmapFilters.tsx
@@ -8,6 +8,9 @@ interface RoadmapFiltersProps {
   availableStatuses: string[];
   selectedStatuses: string[];
   onToggleStatus: (status: string) => void;
+  availableBadges: string[];
+  selectedBadges: string[];
+  onToggleBadge: (badge: string) => void;
   availableTags: string[];
   selectedTags: string[];
   onToggleTag: (tag: string) => void;
@@ -89,6 +92,9 @@ const RoadmapFilters: React.FC<RoadmapFiltersProps> = ({
   availableStatuses,
   selectedStatuses,
   onToggleStatus,
+  availableBadges,
+  selectedBadges,
+  onToggleBadge,
   availableTags,
   selectedTags,
   onToggleTag,
@@ -160,6 +166,11 @@ const RoadmapFilters: React.FC<RoadmapFiltersProps> = ({
       label: lead,
       onRemove: () => onToggleLead(lead),
     })),
+    ...selectedBadges.map((badge) => ({
+      key: `badge:${badge}`,
+      label: `Badge: ${badge}`,
+      onRemove: () => onToggleBadge(badge),
+    })),
     ...selectedTags.map((tag) => ({
       key: `tag:${tag}`,
       label: `Tag: ${tag}`,
@@ -215,7 +226,7 @@ const RoadmapFilters: React.FC<RoadmapFiltersProps> = ({
             )}
           </div>
           <p className="text-sm text-slate-300">
-            Verfeinere die Timeline nach Inhalt, Verantwortlichkeit, Fortschritt und Datenlage.
+            Verfeinere die Timeline nach Inhalt, Badges, Verantwortlichkeit, Fortschritt und Datenlage.
           </p>
         </div>
 
@@ -405,7 +416,7 @@ const RoadmapFilters: React.FC<RoadmapFiltersProps> = ({
 
             <div className={panelClass}>
               <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
-                Zeitraum und Tags
+                Zeitraum, Badges und Tags
               </label>
               <div className="rounded-xl border border-slate-700 bg-slate-950/80 px-3 py-3">
                 <div className="mb-3 flex items-center gap-2 text-xs text-slate-300">
@@ -478,7 +489,33 @@ const RoadmapFilters: React.FC<RoadmapFiltersProps> = ({
                 </div>
               </div>
 
-              <div className="mt-4 max-h-48 overflow-auto pr-1">
+              <div className="mt-4 max-h-36 overflow-auto pr-1">
+                <div className="mb-2 text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                  Badges
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {availableBadges.length === 0 ? (
+                    <span className="text-xs text-slate-500">Keine Badges vorhanden</span>
+                  ) : (
+                    availableBadges.map((badge) => (
+                      <button
+                        key={badge}
+                        type="button"
+                        onClick={() => onToggleBadge(badge)}
+                        className={chipClass(selectedBadges.includes(badge))}
+                        title={badge}
+                      >
+                        {badge}
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+
+              <div className="mt-4 max-h-40 overflow-auto pr-1">
+                <div className="mb-2 text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                  Tags
+                </div>
                 <div className="flex flex-wrap gap-2">
                   {availableTags.length === 0 ? (
                     <span className="text-xs text-slate-500">Keine Tags vorhanden</span>

--- a/pages/admin/projects/edit/[id].tsx
+++ b/pages/admin/projects/edit/[id].tsx
@@ -194,6 +194,7 @@ const EditProjectPage: FC = () => {
         endQuarter: updatedProject.endQuarter || '',
         description: updatedProject.description || '',
         status: updatedProject.status || 'planned',
+        badges: updatedProject.badges || [],
         projektleitung: updatedProject.projektleitung || '',
         bisher: updatedProject.bisher || '',
         zukunft: updatedProject.zukunft || '',

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,6 +9,7 @@ export interface Project {
   description: string;
   status: 'planned' | 'in-progress' | 'completed' | 'paused' | 'cancelled';
   ProjectFields: string[];
+  badges?: string[];
   projektleitung: string;
   projektleitungImageUrl?: string | null;
   teamMembers?: TeamMember[];

--- a/utils/clientDataService.ts
+++ b/utils/clientDataService.ts
@@ -594,6 +594,8 @@ class ClientDataService {
       'StartDate',
       'EndDate',
       'ProjectFields',
+      'Badges',
+      'ProjectBadges',
       'Projektphase',
       'NaechsterMeilenstein',
     ];
@@ -770,7 +772,7 @@ class ClientDataService {
       try {
         const minimal = await this.fetchFromSharePoint(
           resolvedProjects,
-          'Id,Title,Category,StartQuarter,EndQuarter,Description,Status,Projektleitung,Bisher,Zukunft,Fortschritt,GeplantUmsetzung,Budget,StartDate,EndDate,ProjectFields,Projektphase,NaechsterMeilenstein'
+          'Id,Title,Category,StartQuarter,EndQuarter,Description,Status,Projektleitung,Bisher,Zukunft,Fortschritt,GeplantUmsetzung,Budget,StartDate,EndDate,ProjectFields,Badges,ProjectBadges,Projektphase,NaechsterMeilenstein'
         );
         initialResult = Array.isArray(minimal) ? minimal : [];
       } catch (e) {
@@ -806,7 +808,7 @@ class ClientDataService {
       try {
         const alt = await this.fetchFromSharePoint(
           resolvedProjects,
-          'Id,Title,Category,StartQuarter,EndQuarter,Description,Status,Projektleitung,Bisher,Zukunft,Fortschritt,GeplantUmsetzung,Budget,StartDate,EndDate,ProjectFields,Projektphase,NaechsterMeilenstein'
+          'Id,Title,Category,StartQuarter,EndQuarter,Description,Status,Projektleitung,Bisher,Zukunft,Fortschritt,GeplantUmsetzung,Budget,StartDate,EndDate,ProjectFields,Badges,ProjectBadges,Projektphase,NaechsterMeilenstein'
         );
         if (Array.isArray(alt) && alt.length > 0) items = alt;
       } catch {
@@ -836,6 +838,7 @@ class ClientDataService {
             StartDate: '',
             EndDate: '',
             ProjectFields: [],
+            Badges: [],
           }));
         }
       } catch {
@@ -987,6 +990,24 @@ class ClientDataService {
           else projectFields = [raw.trim()];
         }
       }
+      let badges: string[] = [];
+      const rawBadges = item.Badges ?? item.ProjectBadges;
+      if (rawBadges) {
+        if (Array.isArray(rawBadges)) badges = rawBadges;
+        else if (typeof rawBadges === 'string') {
+          if (rawBadges.includes('\n'))
+            badges = rawBadges
+              .split('\n')
+              .map((s: string) => s.trim())
+              .filter(Boolean);
+          else if (rawBadges.includes(';') || rawBadges.includes(','))
+            badges = rawBadges
+              .split(/[;,]/)
+              .map((s: string) => s.trim())
+              .filter(Boolean);
+          else badges = [rawBadges.trim()];
+        }
+      }
       const normalizedCategory = getNormalizedCategoryFromEntity(item);
       if (normalizedCategory) item.Category = normalizedCategory;
 
@@ -1011,6 +1032,7 @@ class ClientDataService {
         description: item.Description || '',
         status: String(item.Status || 'planned').toLowerCase() as any,
         ProjectFields: projectFields,
+        badges,
         projektleitung: item.Projektleitung || '',
         bisher: item.Bisher || '',
         zukunft: item.Zukunft || '',
@@ -1155,6 +1177,8 @@ class ClientDataService {
         'ProjectFields',
       ];
       if (listFields?.has('ProjectType')) baseSelectFields.push('ProjectType');
+      if (listFields?.has('Badges')) baseSelectFields.push('Badges');
+      if (listFields?.has('ProjectBadges')) baseSelectFields.push('ProjectBadges');
       if (listFields?.has('Projektphase')) baseSelectFields.push('Projektphase');
       if (listFields?.has('NaechsterMeilenstein')) baseSelectFields.push('NaechsterMeilenstein');
 
@@ -1248,6 +1272,7 @@ class ClientDataService {
             built.budget = built.budget || fromList.budget;
             if (!built.ProjectFields?.length && fromList.ProjectFields?.length)
               built.ProjectFields = fromList.ProjectFields;
+            if (!built.badges?.length && fromList.badges?.length) built.badges = fromList.badges;
             if (!built.projektphase && fromList.projektphase)
               built.projektphase = fromList.projektphase;
             if (!built.naechster_meilenstein && fromList.naechster_meilenstein)
@@ -1285,6 +1310,24 @@ class ClientDataService {
         else projectFields = [raw.trim()];
       }
     }
+    let badges: string[] = [];
+    const rawBadges = item.Badges ?? item.ProjectBadges;
+    if (rawBadges) {
+      if (Array.isArray(rawBadges)) badges = rawBadges;
+      else if (typeof rawBadges === 'string') {
+        if (rawBadges.includes('\n'))
+          badges = rawBadges
+            .split('\n')
+            .map((s: string) => s.trim())
+            .filter(Boolean);
+        else if (rawBadges.includes(';') || rawBadges.includes(','))
+          badges = rawBadges
+            .split(/[;,]/)
+            .map((s: string) => s.trim())
+            .filter(Boolean);
+        else badges = [rawBadges.trim()];
+      }
+    }
 
     const teamMembers = await this.getTeamMembersForProject(id);
     const links = await this.getProjectLinks(id);
@@ -1303,6 +1346,7 @@ class ClientDataService {
       description: item.Description || '',
       status: (item.Status?.toLowerCase?.() || 'planned') as any,
       ProjectFields: projectFields,
+      badges,
       projektleitung: item.Projektleitung || '',
       projektleitungImageUrl: null,
       teamMembers: teamMembers,
@@ -1421,6 +1465,7 @@ class ClientDataService {
 
       // Process ProjectFields value
       let projectFieldsValue = '';
+      let badgesValue = '';
 
       if (projectData.ProjectFields !== undefined) {
         if (Array.isArray(projectData.ProjectFields)) {
@@ -1436,6 +1481,22 @@ class ClientDataService {
           projectFieldsValue = existingProject.ProjectFields.join('; ');
         } else {
           projectFieldsValue = String(existingProject.ProjectFields);
+        }
+      }
+
+      if (projectData.badges !== undefined) {
+        if (Array.isArray(projectData.badges)) {
+          badgesValue = projectData.badges.join('; ');
+        } else if (typeof projectData.badges === 'string') {
+          badgesValue = projectData.badges;
+        } else if (projectData.badges) {
+          badgesValue = String(projectData.badges);
+        }
+      } else if (existingProject.badges) {
+        if (Array.isArray(existingProject.badges)) {
+          badgesValue = existingProject.badges.join('; ');
+        } else {
+          badgesValue = String(existingProject.badges);
         }
       }
 
@@ -1470,6 +1531,11 @@ class ClientDataService {
           const nextType = (projectData as any).projectType || (existingProject as any).projectType;
           if (nextType)
             body['ProjectType'] = String(nextType).toLowerCase() === 'short' ? 'short' : 'long';
+        }
+        if (fields.has('Badges')) {
+          body['Badges'] = badgesValue;
+        } else if (fields.has('ProjectBadges')) {
+          body['ProjectBadges'] = badgesValue;
         }
         if (fields.has('Projektphase')) {
           const phaseRaw =
@@ -2240,6 +2306,11 @@ class ClientDataService {
         if (fields.has('ProjectType')) {
           const pt = (projectData as any).projectType;
           if (pt) body['ProjectType'] = String(pt).toLowerCase() === 'short' ? 'short' : 'long';
+        }
+        if (fields.has('Badges')) {
+          body['Badges'] = cleanFields((projectData as any).badges);
+        } else if (fields.has('ProjectBadges')) {
+          body['ProjectBadges'] = cleanFields((projectData as any).badges);
         }
         if (fields.has('Projektphase')) {
           const phaseRaw = (projectData as any).projektphase || '';


### PR DESCRIPTION
Introduce optional badge metadata and UI across the app so projects can have small labeled badges that are displayed, edited and used for filtering.

Key changes:
- types: add optional badges?: string[] to Project.
- components/ProjectForm.tsx: add badge state, normalization, add/remove handlers and UI for entering badges (including keyboard handling) and include badges in form submission.
- components/CompactProjectCard.tsx: render project.badges as chips in the compact card.
- components/Roadmap.tsx: load/save badge filters to query string, include badges in search, derive allBadges from displayed projects, apply badge filters and wire toggle handlers.
- components/RoadmapFilters.tsx: add badge chips to filters UI and include badges in the active filter list.
- pages/admin/projects/edit/[id].tsx: include badges when assembling project payload for the edit page.
- utils/clientDataService.ts: request Badges/ProjectBadges fields from SharePoint, parse varied formats into a badges array, include badges when building project objects, and send badges when creating/updating items.

Why: Enables tagging projects with short labels for display and enhanced filtering on the roadmap and card views.