### PR TITLE
fixed bugs

### DIFF
--- a/pages/api/instances/select.ts
+++ b/pages/api/instances/select.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getInstanceConfigBySlug, setInstanceCookieHeader } from '@/utils/instanceConfig';
 import { requireUserSession } from '@/utils/apiAuth';
-import { isAdminSessionAllowedForInstance } from '@/utils/instanceAccessServer';
+import { isReadSessionAllowedForInstance } from '@/utils/instanceAccessServer';
 import { sanitizeSlug } from './helpers';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -35,7 +35,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   };
 
   if (
-    !(await isAdminSessionAllowedForInstance({
+    !(await isReadSessionAllowedForInstance({
       session,
       instance,
       requestHeaders: forwardedHeaders,

--- a/pages/api/instances/slugs.ts
+++ b/pages/api/instances/slugs.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import prisma from '@/lib/prisma';
 import { extractAdminSession } from '@/utils/apiAuth';
-import { isReadSessionAllowedForInstance } from '@/utils/instanceAccessServer';
+import { isSessionExplicitlyAllowedByDepartmentForInstance } from '@/utils/instanceAccessServer';
 import { isSuperAdminSessionWithSharePointFallback } from '@/utils/superAdminAccessServer';
 
 const HTTP_URL_REGEX = /^https?:\/\//i;
@@ -170,7 +170,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const checks = await Promise.all(
       allRecords.map(async (r) => ({
         record: r,
-        allowed: await isReadSessionAllowedForInstance({
+        allowed: await isSessionExplicitlyAllowedByDepartmentForInstance({
           session,
           instance: { slug: r.slug },
           requestHeaders: forwardedHeaders,

--- a/pages/api/projects/index.ts
+++ b/pages/api/projects/index.ts
@@ -154,6 +154,16 @@ const mapMinimalSharePointItem = (item: Record<string, unknown>): Project => {
         ? (String(item.Status).toLowerCase() as Project['status'])
         : 'planned',
     ProjectFields: [],
+    badges:
+      typeof item.Badges === 'string'
+        ? item.Badges.split(/[;,\n]/)
+            .map((entry) => entry.trim())
+            .filter(Boolean)
+        : typeof item.ProjectBadges === 'string'
+          ? item.ProjectBadges.split(/[;,\n]/)
+              .map((entry) => entry.trim())
+              .filter(Boolean)
+          : [],
     projektleitung: typeof item.Projektleitung === 'string' ? item.Projektleitung : '',
     teamMembers: [],
     bisher: typeof item.Bisher === 'string' ? item.Bisher : '',
@@ -201,7 +211,7 @@ const fetchProjectsViaExplicitInstanceProxy = async (
   const encodedInstance = encodeURIComponent(instance.slug);
   const candidateLists = ['Roadmap Projects'];
   const select = encodeURIComponent(
-    'Id,Title,ProjectType,Category,Bereich,Bereiche,StartQuarter,EndQuarter,Description,Status,Projektleitung,Bisher,Zukunft,Fortschritt,GeplantUmsetzung,Budget,StartDate,EndDate'
+    'Id,Title,ProjectType,Category,Bereich,Bereiche,StartQuarter,EndQuarter,Description,Status,Projektleitung,Bisher,Zukunft,Fortschritt,GeplantUmsetzung,Budget,StartDate,EndDate,Badges,ProjectBadges'
   );
   const probe: string[] = [];
 

--- a/pages/api/public/projects.ts
+++ b/pages/api/public/projects.ts
@@ -78,6 +78,16 @@ const filterProjects = (list: Project[], query: NextApiRequest['query']): Projec
     .split(',')
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean);
+  const badgeFilterRaw =
+    typeof query.badges === 'string'
+      ? query.badges
+      : Array.isArray(query.badges)
+        ? query.badges.join(',')
+        : '';
+  const badgeFilters = badgeFilterRaw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
   const q = typeof query.q === 'string' ? query.q.trim().toLowerCase() : '';
 
   return list.filter((p) => {
@@ -89,8 +99,19 @@ const filterProjects = (list: Project[], query: NextApiRequest['query']): Projec
       const status = toLower(p.status);
       if (!statusFilters.includes(status)) return false;
     }
+    if (badgeFilters.length) {
+      const badges = (p.badges || []).map((badge) => String(badge).trim().toLowerCase());
+      if (!badgeFilters.some((badge) => badges.includes(badge))) return false;
+    }
     if (q) {
-      const haystack = [p.title, p.description, p.bisher, p.zukunft, p.geplante_umsetzung]
+      const haystack = [
+        p.title,
+        p.description,
+        p.bisher,
+        p.zukunft,
+        p.geplante_umsetzung,
+        ...(p.badges || []),
+      ]
         .filter(Boolean)
         .map((s) => s!.toLowerCase())
         .join(' \n ');

--- a/pages/instances.tsx
+++ b/pages/instances.tsx
@@ -27,7 +27,7 @@ import {
   persistAdminSession,
 } from '@/utils/auth';
 import { extractAdminSessionFromHeaders } from '@/utils/apiAuth';
-import { isReadSessionAllowedForInstance } from '@/utils/instanceAccessServer';
+import { isSessionExplicitlyAllowedByDepartmentForInstance } from '@/utils/instanceAccessServer';
 import { isSuperAdminSessionWithSharePointFallback } from '@/utils/superAdminAccessServer';
 
 const HTTP_URL_REGEX = /^https?:\/\//i;
@@ -675,7 +675,7 @@ const InstancesPage = ({ instances }: LandingPageProps) => {
                   <p className="mt-2 text-sm">
                     {canManageInstances
                       ? 'Erstelle in der Instanzverwaltung eine neue Roadmap-Instanz und verknüpfe den passenden SharePoint-Endpunkt.'
-                      : 'Dir ist aktuell keine Roadmap-Instanz per Abteilung oder Admin-Berechtigung zugeordnet.'}
+                      : 'Dir ist aktuell keine Roadmap-Instanz über die explizit freigegebenen Abteilungen zugeordnet.'}
                   </p>
                 </div>
               )}
@@ -783,7 +783,7 @@ export const getServerSideProps: GetServerSideProps<LandingPageProps> = async (c
   const checks = await Promise.all(
     records.map(async (r) => {
       try {
-        const allowed = await isReadSessionAllowedForInstance({
+        const allowed = await isSessionExplicitlyAllowedByDepartmentForInstance({
           session,
           instance: { slug: r.slug },
           requestHeaders: forwardedHeaders,

--- a/utils/instanceAccessServer.ts
+++ b/utils/instanceAccessServer.ts
@@ -142,6 +142,54 @@ async function isSessionAllowedForInstance(opts: {
   }
 }
 
+export async function isSessionExplicitlyAllowedByDepartmentForInstance(opts: {
+  session: AdminSessionPayload;
+  instance: Pick<RoadmapInstanceConfig, 'slug' | 'metadata'>;
+  requestHeaders?: ForwardedRequestHeaders;
+}): Promise<boolean> {
+  const effectiveInstance =
+    opts.instance.metadata !== undefined
+      ? opts.instance
+      : ((await getInstanceConfigBySlug(String(opts.instance.slug || ''))) ?? opts.instance);
+
+  if (
+    await isSuperAdminSessionWithSharePointFallback(opts.session, {
+      requestHeaders: opts.requestHeaders,
+    })
+  ) {
+    return true;
+  }
+
+  const ids = extractIdentifiers(opts.session);
+  if (!ids.department) {
+    const resolvedOnPremDepartment = await clientDataService.withRequestHeaders(
+      opts.requestHeaders,
+      () =>
+        clientDataService.withInstance(String(effectiveInstance.slug || ''), () =>
+          clientDataService.resolveUserDepartmentFromSharePoint({
+            username: ids.username,
+            upn: ids.upn,
+            mail: ids.mail,
+            displayName: ids.displayName,
+          })
+        )
+    );
+    if (resolvedOnPremDepartment) {
+      ids.department = resolvedOnPremDepartment;
+    }
+  }
+
+  const departmentCandidates = Array.from(
+    new Set([ids.department].map((value) => normalizeDepartment(value)).filter(Boolean))
+  );
+  if (departmentCandidates.length === 0) return false;
+
+  return isAnyDepartmentCandidateAllowedForInstance({
+    instanceSlug: String(effectiveInstance.slug || ''),
+    candidates: departmentCandidates,
+  });
+}
+
 export async function isAdminSessionAllowedForInstance(opts: {
   session: AdminSessionPayload;
   instance: Pick<RoadmapInstanceConfig, 'slug' | 'metadata'>;

--- a/utils/sharePointLists.ts
+++ b/utils/sharePointLists.ts
@@ -94,6 +94,11 @@ export const SHAREPOINT_LIST_DEFINITIONS: SharePointListDefinition[] = [
           '<Field DisplayName="ProjectFields" Name="ProjectFields" Type="Note" NumLines="6" RichText="FALSE" />',
       },
       {
+        name: 'Badges',
+        schemaXml:
+          '<Field DisplayName="Badges" Name="Badges" Type="Note" NumLines="6" RichText="FALSE" />',
+      },
+      {
         name: 'Projektphase',
         schemaXml:
           '<Field DisplayName="Projektphase" Name="Projektphase" Type="Text" MaxLength="60" />',


### PR DESCRIPTION
This pull request introduces two main improvements: it refines how project "badges" are handled and filtered throughout the API, and it updates the access control logic for instances to use more explicit department-based checks. The changes ensure that badges are consistently imported, exposed, and filterable, and that users only see instances explicitly allowed for their department.

**Badge handling and filtering improvements:**

* Projects now import both `Badges` and `ProjectBadges` fields from SharePoint, combine them, and expose them as a unified `badges` array in the API (`pages/api/projects/index.ts`, `utils/sharePointLists.ts`). [[1]](diffhunk://#diff-750f5e7d8f92bc027e28f9edf711edc0c34f08c37c9105d4a318ce9387bb091aR157-R166) [[2]](diffhunk://#diff-750f5e7d8f92bc027e28f9edf711edc0c34f08c37c9105d4a318ce9387bb091aL204-R214) [[3]](diffhunk://#diff-ed378bd8b71fb490f656ec60850560eaaa5e31140d9a0669e5528f9df4d6579cR96-R100)
* The public projects API now supports filtering by badges via a `badges` query parameter and includes badge values in full-text search (`pages/api/public/projects.ts`). [[1]](diffhunk://#diff-b6cad54688b69bdc092b5ade943c4b63701af1c4221e12276876dff5a03509c7R81-R90) [[2]](diffhunk://#diff-b6cad54688b69bdc092b5ade943c4b63701af1c4221e12276876dff5a03509c7R102-R114)

**Access control and permissions updates:**

* Replaces generic read-access checks with `isSessionExplicitlyAllowedByDepartmentForInstance`, ensuring that only users whose departments are explicitly allowed can access instances or see them in listings (`pages/api/instances/slugs.ts`, `pages/instances.tsx`, `utils/instanceAccessServer.ts`). [[1]](diffhunk://#diff-b82b82856d4b5bac3d07dbe03629c138dfe222b9a989409e4d349c3fd6e59d11L4-R4) [[2]](diffhunk://#diff-b82b82856d4b5bac3d07dbe03629c138dfe222b9a989409e4d349c3fd6e59d11L173-R173) [[3]](diffhunk://#diff-ee81c0719b0f516525473cf987bc4c6d2b360eb6fd79606ffbba09bd42838964L30-R30) [[4]](diffhunk://#diff-ee81c0719b0f516525473cf987bc4c6d2b360eb6fd79606ffbba09bd42838964L786-R786) [[5]](diffhunk://#diff-aba877e1252376eac2986ed2237652d3ad9346e37948db4d36af60b9091721f1R145-R192)
* Updates user-facing text to clarify that instance access is determined by explicit department assignment, not just general admin or department membership (`pages/instances.tsx`).
* Adjusts the instance selection API to use a read-access check that aligns with the new department-based logic (`pages/api/instances/select.ts`). [[1]](diffhunk://#diff-d887975feb46e103fce127d9d5f23e6a592c64202b2fce70b140eaf521a1799bL4-R4) [[2]](diffhunk://#diff-d887975feb46e103fce127d9d5f23e6a592c64202b2fce70b140eaf521a1799bL38-R38)